### PR TITLE
Add ability to exclude scopes

### DIFF
--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -238,6 +238,38 @@ describe('Supports excluding packages', () => {
     test('does not break if scope is missing', () => testWithFlags(['--exclude', '@foo']));
 });
 
+describe('Supports excluding scopes', () => {
+    test('it accepts a single scope', async () => {
+        const stdout = await testWithFlags(['--exclude-scopes', '@scope']);
+        expect(stdout).toContain('"@scope/lib@>=1.0.0":');
+        expect(stdout).not.toContain('"@scope/lib@>=1.0.0", "@scope/lib@>=2.0.0":');
+    });
+
+    test('it accepts a multiple scopes in one flag', async () => {
+        const stdout = await testWithFlags(['--exclude-scopes', '@scope', '@another-scope']);
+        expect(stdout).toContain('"@scope/lib@>=1.0.0":');
+        expect(stdout).toContain('"@another-scope/lib@>=1.0.0":');
+        expect(stdout).not.toContain('"@scope/lib@>=1.0.0", "@scope/lib@>=2.0.0":');
+        expect(stdout).not.toContain('"@another-scope/lib@>=1.0.0", "@another-scope/lib@>=2.0.0":');
+    });
+
+    test('it accepts a multiple flags', async () => {
+        const stdout = await testWithFlags([
+            '--exclude-scopes',
+            '@scope',
+            '--exclude-scopes',
+            '@another-scope',
+        ]);
+        expect(stdout).toContain('"@scope/lib@>=1.0.0":');
+        expect(stdout).toContain('"@another-scope/lib@>=1.0.0":');
+        expect(stdout).not.toContain('"@scope/lib@>=1.0.0", "@scope/lib@>=2.0.0":');
+        expect(stdout).not.toContain('"@another-scope/lib@>=1.0.0", "@another-scope/lib@>=2.0.0":');
+    });
+
+    // eslint-disable-next-line jest/expect-expect
+    test('does not break if scope is missing', () => testWithFlags(['--scopes', '@foo']));
+});
+
 test('line endings are retained', async () => {
     const oldFileContent = await readFile(yarnLockFilePath, 'utf8');
     try {

--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,7 @@ commander
         'a list of packages to deduplicate. Defaults to all packages.'
     )
     .option('--exclude <exclude...>', 'a list of packages not to deduplicate.')
+    .option('--exclude-scopes <excluded scopes...>', 'a list of scopes not to deduplicate.')
     .option('--print', 'instead of saving the deduplicated yarn.lock, print the result in stdout')
     .option(
         '--includePrerelease',
@@ -55,6 +56,7 @@ try {
             includeScopes: commander.scopes,
             includePackages: commander.packages,
             excludePackages: commander.exclude,
+            excludeScopes: commander.excludeScopes,
         });
         duplicates.forEach((logLine) => console.log(logLine));
         if (commander.fail && duplicates.length > 0) {
@@ -66,6 +68,7 @@ try {
             includeScopes: commander.scopes,
             includePackages: commander.packages,
             excludePackages: commander.exclude,
+            excludeScopes: commander.excludeScopes,
             includePrerelease: commander.includePrerelease,
         });
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,13 @@ const semver = require('semver');
 
 const parseYarnLock = (file) => lockfile.parse(file).object;
 
-const extractPackages = (json, includeScopes = [], includePackages = [], excludePackages = []) => {
+const extractPackages = (
+    json,
+    includeScopes = [],
+    includePackages = [],
+    excludePackages = [],
+    excludeScopes = []
+) => {
     const packages = {};
     const re = /^(.*)@([^@]*?)$/;
 
@@ -30,6 +36,13 @@ const extractPackages = (json, includeScopes = [], includePackages = [], exclude
         if (
             includeScopes.length > 0 &&
             !includeScopes.find((scope) => packageName.startsWith(`${scope}/`))
+        ) {
+            return;
+        }
+
+        if (
+            excludeScopes.length > 0 &&
+            excludeScopes.find((scope) => packageName.startsWith(`${scope}/`))
         ) {
             return;
         }
@@ -111,9 +124,22 @@ const computePackageInstances = (packages, name, useMostCommon, includePrereleas
 
 const getDuplicatedPackages = (
     json,
-    { includeScopes, includePackages, excludePackages, useMostCommon, includePrerelease = false }
+    {
+        includeScopes,
+        includePackages,
+        excludePackages,
+        excludeScopes,
+        useMostCommon,
+        includePrerelease = false,
+    }
 ) => {
-    const packages = extractPackages(json, includeScopes, includePackages, excludePackages);
+    const packages = extractPackages(
+        json,
+        includeScopes,
+        includePackages,
+        excludePackages,
+        excludeScopes
+    );
     return Object.keys(packages)
         .reduce(
             (acc, name) =>
@@ -131,6 +157,7 @@ module.exports.listDuplicates = (
         includeScopes = [],
         includePackages = [],
         excludePackages = [],
+        excludeScopes = [],
         useMostCommon = false,
         includePrerelease = false,
     } = {}
@@ -142,6 +169,7 @@ module.exports.listDuplicates = (
         includeScopes,
         includePackages,
         excludePackages,
+        excludeScopes,
         useMostCommon,
         includePrerelease,
     }).forEach(({ bestVersion, name, installedVersion, requestedVersion }) => {
@@ -159,6 +187,7 @@ module.exports.fixDuplicates = (
         includeScopes = [],
         includePackages = [],
         excludePackages = [],
+        excludeScopes = [],
         useMostCommon = false,
         includePrerelease = false,
     } = {}
@@ -169,6 +198,7 @@ module.exports.fixDuplicates = (
         includeScopes,
         includePackages,
         excludePackages,
+        excludeScopes,
         useMostCommon,
         includePrerelease,
     }).forEach(({ bestVersion, name, versions, requestedVersion }) => {


### PR DESCRIPTION
This PR adds the ability to exclude certain scopes from deduplication. This is required in our case as we want to upgrade our own scopes with `--strategy highest` and everything else with `--strategy fewer`.