### PR TITLE
Add explicit example of npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ yarn global add yarn-deduplicate
 
 This package also works wth
 [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b), so you
-don't need to install it.
+don't need to install it. For example, to recreate the most common scenario below with `npx`, run:
+
+```sh
+npx yarn-deduplicate yarn.lock
+```
 
 ---
 


### PR DESCRIPTION
Hi, thanks for `yarn-deduplicate`, really useful! 🙌

I was looking for an explicit copy-pastable example of usage with `npx`, but didn't see one (I would actually expect this to be the first example, not installation globally, but that's a different discussion).

This PR adds an example of usage with `npx` to the readme.